### PR TITLE
Fix syntax error in accountRoutes

### DIFF
--- a/ledger/server/routes/accountRoutes.js
+++ b/ledger/server/routes/accountRoutes.js
@@ -21,7 +21,6 @@ router.get('/sub-accounts', accountController.getAllSubAccounts);
 router.post('/sub-accounts', accountController.createSubAccount);
 
 // Get All Classes
-router.get('/classes', accountController.getAllClasses,
-);
+router.get('/classes', accountController.getAllClasses);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- fix malformed Express route for `/classes`

## Testing
- `npm test --prefix server` *(fails: no test specified)*
- `npm test --silent --prefix client` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848491f1b948332b216ad9b80d8e92a