### PR TITLE
Fix typo in DB reset script

### DIFF
--- a/ledger/server/db/scripts/resetdb.js
+++ b/ledger/server/db/scripts/resetdb.js
@@ -50,7 +50,7 @@ const resetDB = async () => {
     console.log("-- COMPLETED --");
     client.end();
   } catch (e) {
-    console.log("ERROR OCCURED:\n", e);
+    console.log("ERROR OCCURRED:\n", e);
     client.end();
   }
 };


### PR DESCRIPTION
## Summary
- fix misspelling in `resetdb.js` error message

## Testing
- `npm --prefix ledger/client test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm --prefix ledger/server test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856d014370083328b5762d0984c1a1f