### PR TITLE
Update test expectation for dashboard text

### DIFF
--- a/ledger/client/src/tests/App.test.js
+++ b/ledger/client/src/tests/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from '../App';
 
-test('renders learn react link', () => {
+test('renders dashboard with Total Income text', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const metricElement = screen.getByText(/Total Income/i);
+  expect(metricElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- check for dashboard content in App test

## Testing
- `npm test -- -w` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d0832ab0833289600dad2e4feee7