### PR TITLE
Fix header comment

### DIFF
--- a/ledger/client/src/context/EntryContext.js
+++ b/ledger/client/src/context/EntryContext.js
@@ -1,4 +1,4 @@
-// AccountContext.js
+// EntryContext.js
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import axios from 'axios';
 


### PR DESCRIPTION
## Summary
- correct comment header for `EntryContext.js`

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d07cb8a08332b80d3e9aa3835234