### PR TITLE
Introduce blockchain service layer

### DIFF
--- a/ledger/docs/blockchain_hooks.md
+++ b/ledger/docs/blockchain_hooks.md
@@ -1,0 +1,24 @@
+# Backend Blockchain Integration Hooks
+
+This project supports optional interaction with the blockchain layer. The main server
+remains decoupled through a service layer and can run without the blockchain
+module present.
+
+## Environment Toggle
+Set `USE_BLOCKCHAIN=true` in the server environment to enable calls to the blockchain service.
+
+## Service API
+`server/services/blockchainService.js` exposes the following asynchronous method:
+
+- `recordTransaction(transaction)` – Accepts the persisted transaction object and
+  records it on the blockchain. The default implementation is a stub and simply
+  resolves the promise.
+
+Additional hooks can be added here as blockchain features grow (for example,
+`verifyTransaction` or `getTransactionStatus`).
+
+## Usage
+`server/services/transactionService.js` calls `recordTransaction` when
+`USE_BLOCKCHAIN` is enabled. Controllers should use
+`transactionService.createTransactionWithBlockchain` instead of direct database
+access so that blockchain functionality can be integrated transparently.

--- a/ledger/server/.env.example
+++ b/ledger/server/.env.example
@@ -1,0 +1,2 @@
+# Example environment variables
+USE_BLOCKCHAIN=false

--- a/ledger/server/controllers/entriesController.js
+++ b/ledger/server/controllers/entriesController.js
@@ -1,28 +1,13 @@
 // entriesController.js
 /* eslint-disable camelcase */
-const { Pool } = require("pg");
-const pool = require("../db/config");
+const transactionService = require("../services/transactionService");
 
 const createEntry = async (req, res) => {
   try {
-    const { account_number, sub_account_number, fk_user_id, amount, timestamp, reference, note, transaction_id } = req.body;
-
-    // Insert a new transaction into the transactions table
-    const query = `
-      INSERT INTO transactions (account_number, sub_account_number, fk_user_id, amount, timestamp, reference, note, transaction_id)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-      RETURNING *;
-    `;
-
-    const values = [account_number, sub_account_number, fk_user_id, amount, timestamp, reference, note, transaction_id];
-
-    const result = await pool.query(query, values);
-
-    // Send a success response with the created transaction
-    res.status(201).json({ transaction: result.rows[0] });
+    const inserted = await transactionService.createTransactionWithBlockchain(req.body);
+    res.status(201).json({ transaction: inserted });
     console.log("Transaction Posted");
   } catch (error) {
-    // Handle any errors and send an error response
     console.error(error);
     res.status(500).json({ error: "Internal server error" });
   }
@@ -33,17 +18,8 @@ const getEntriesbyPeriod = async (req, res) => {
   try {
     const { period } = req.query;
 
-    // Fetch entries by period from the transactions table
-    const query = `
-      SELECT * FROM transactions
-      ORDER BY timestamp DESC
-      LIMIT $1;
-    `;
-    const values = [period];
-    const result = await pool.query(query, values);
-
-    // Send a success response with the retrieved entries
-    res.status(200).json({ entries: result.rows });
+    const entries = await transactionService.getEntriesByPeriod(period);
+    res.status(200).json({ entries });
     console.log("Retrieved entries by period");
   } catch (error) {
     // Handle any errors and send an error response

--- a/ledger/server/services/blockchainService.js
+++ b/ledger/server/services/blockchainService.js
@@ -1,0 +1,19 @@
+/**
+ * Stubbed blockchain integration layer.
+ * Replace implementations once blockchain module is ready.
+ */
+
+/**
+ * Record a transaction on the blockchain.
+ * @param {Object} tx transaction data saved in the DB
+ * @returns {Promise<void>} resolves when recorded
+ */
+async function recordTransaction(tx) {
+  // Placeholder for future blockchain logic
+  // For now we simply return resolved promise to keep async behaviour
+  return Promise.resolve();
+}
+
+module.exports = {
+  recordTransaction,
+};

--- a/ledger/server/services/transactionService.js
+++ b/ledger/server/services/transactionService.js
@@ -1,0 +1,83 @@
+const pool = require('../db/config');
+const blockchainService = require('./blockchainService');
+
+/**
+ * Persist a transaction to the database.
+ * @param {Object} tx - transaction data
+ * @returns {Promise<Object>} inserted transaction
+ */
+async function createTransaction(tx) {
+  const {
+    account_number,
+    sub_account_number,
+    fk_user_id,
+    amount,
+    timestamp,
+    reference,
+    note,
+    transaction_id,
+  } = tx;
+
+  const query = `
+    INSERT INTO transactions (
+      account_number,
+      sub_account_number,
+      fk_user_id,
+      amount,
+      timestamp,
+      reference,
+      note,
+      transaction_id
+    ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+    RETURNING *;
+  `;
+  const values = [
+    account_number,
+    sub_account_number,
+    fk_user_id,
+    amount,
+    timestamp,
+    reference,
+    note,
+    transaction_id,
+  ];
+  const result = await pool.query(query, values);
+  return result.rows[0];
+}
+
+/**
+ * Retrieve entries ordered by timestamp.
+ * @param {number} period number of entries to return
+ */
+async function getEntriesByPeriod(period) {
+  const query = `
+    SELECT * FROM transactions
+    ORDER BY timestamp DESC
+    LIMIT $1;
+  `;
+  const values = [period];
+  const result = await pool.query(query, values);
+  return result.rows;
+}
+
+/**
+ * Optionally forward transaction to blockchain layer based on USE_BLOCKCHAIN env var.
+ * @param {Object} tx transaction data
+ */
+async function createTransactionWithBlockchain(tx) {
+  const inserted = await createTransaction(tx);
+  if (process.env.USE_BLOCKCHAIN === 'true') {
+    try {
+      await blockchainService.recordTransaction(inserted);
+    } catch (err) {
+      console.error('Blockchain recording failed:', err);
+    }
+  }
+  return inserted;
+}
+
+module.exports = {
+  createTransaction,
+  getEntriesByPeriod,
+  createTransactionWithBlockchain,
+};


### PR DESCRIPTION
## Summary
- add transaction service that can route writes to blockchain
- stub out a blockchain service layer
- update entries controller to use new service abstraction
- document blockchain hooks and add USE_BLOCKCHAIN env toggle

## Testing
- `npm test` in `ledger/server`
- `npm test` in `ledger/blockchain` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856dde2463c83329bc4a6e7b1484452