### PR TITLE
Add tests for ledger server

### DIFF
--- a/ledger/server/package.json
+++ b/ledger/server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon server.js",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha tests --exit",
     "db:reset": "node db/scripts/resetdb.js"
   },
   "author": "",
@@ -25,7 +25,11 @@
     "sequelize": "^6.32.1"
   },
   "devDependencies": {
+    "chai": "^4.3.7",
+    "mocha": "^10.2.0",
     "morgan": "^1.10.0",
-    "nodemon": "^3.0.1"
+    "nodemon": "^3.0.1",
+    "proxyquire": "^2.1.3",
+    "sinon": "^16.0.0"
   }
 }

--- a/ledger/server/tests/accounts.test.js
+++ b/ledger/server/tests/accounts.test.js
@@ -1,0 +1,111 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+let accounts = [];
+let subAccounts = [];
+
+const queryStub = sinon.stub().callsFake(async (query, values) => {
+  if (/INSERT INTO accounts/i.test(query)) {
+    const account = { id: accounts.length + 1, ...valuesToAccount(values) };
+    accounts.push(account);
+    return { rows: [], rowCount: 1 };
+  }
+  if (/SELECT \* FROM accounts/i.test(query)) {
+    return { rows: accounts };
+  }
+  if (/UPDATE accounts/i.test(query)) {
+    const id = values[5];
+    const idx = accounts.findIndex((a) => a.id === id);
+    if (idx === -1) return { rowCount: 0 };
+    accounts[idx] = { ...accounts[idx], ...valuesToAccount(values) };
+    return { rowCount: 1 };
+  }
+  if (/SELECT \* FROM sub_accounts WHERE fk_account_id =/i.test(query)) {
+    const id = values[0];
+    return { rows: subAccounts.filter((s) => s.fk_account_id === id) };
+  }
+  if (/SELECT \* FROM sub_accounts;/i.test(query)) {
+    return { rows: subAccounts };
+  }
+  if (/INSERT INTO sub_accounts/i.test(query)) {
+    const sub = { id: subAccounts.length + 1, ...valuesToSub(values) };
+    subAccounts.push(sub);
+    return { rows: [], rowCount: 1 };
+  }
+  return { rows: [] };
+});
+
+function valuesToAccount(values) {
+  return {
+    name: values[0],
+    account_number: values[1],
+    account_type: values[2],
+    fk_class_id: values[3],
+    fk_user_id: values[4],
+    master_account: `${values[3]}-${values[1]}-0000`,
+  };
+}
+
+function valuesToSub(values) {
+  return {
+    name: values[0],
+    account_number: values[1],
+    account_type: values[2],
+    fk_account_id: values[3],
+    fk_class_id: values[4],
+    fk_user_id: values[5],
+    master_account: `${values[4]}-${accounts.find(a=>a.id===values[3]).account_number}-${values[1]}`,
+  };
+}
+
+const accountController = proxyquire('../controllers/accountController', {
+  '../db/config': { query: queryStub },
+});
+
+describe('accountController CRUD', () => {
+  beforeEach(() => {
+    accounts = [];
+    subAccounts = [];
+    queryStub.resetHistory();
+  });
+
+  it('creates and retrieves accounts', async () => {
+    const req = { body: { name: 'Cash', account_number: '1001', account_type: 'Debit', fk_class_id: 10, fk_user_id: 1 } };
+    const res = { status: sinon.stub().returnsThis(), json: sinon.stub() };
+    await accountController.createAccount(req, res);
+    expect(res.status.calledWith(201)).to.be.true;
+
+    const getRes = { status: sinon.stub().returnsThis(), json: sinon.stub() };
+    await accountController.getAllAccounts({}, getRes);
+    expect(getRes.json.firstCall.args[0].accounts).to.have.length(1);
+  });
+
+  it('updates an existing account', async () => {
+    const req = { body: { name: 'Cash', account_number: '1001', account_type: 'Debit', fk_class_id: 10, fk_user_id: 1 } };
+    const res = { status: sinon.stub().returnsThis(), json: sinon.stub() };
+    await accountController.createAccount(req, res);
+
+    const updateRes = { status: sinon.stub().returnsThis(), json: sinon.stub() };
+    const updateReq = { params: { id: 1 }, body: { name: 'Petty Cash', account_number: '1001', account_type: 'Debit', fk_class_id: 10, fk_user_id: 1 } };
+    await accountController.editAccount(updateReq, updateRes);
+    expect(updateRes.status.calledWith(200)).to.be.true;
+  });
+
+  it('creates and retrieves sub-accounts', async () => {
+    // create parent account first
+    const req = { body: { name: 'Cash', account_number: '1001', account_type: 'Debit', fk_class_id: 10, fk_user_id: 1 } };
+    const res = { status: sinon.stub().returnsThis(), json: sinon.stub() };
+    await accountController.createAccount(req, res);
+
+    const subReq = { body: { name: 'Petty', account_number: '01', account_type: 'Debit', fk_account_id: 1, fk_class_id: 10, fk_user_id: 1 } };
+    const subRes = { status: sinon.stub().returnsThis(), json: sinon.stub() };
+    await accountController.createSubAccount(subReq, subRes);
+    expect(subRes.status.calledWith(201)).to.be.true;
+
+    const listRes = { status: sinon.stub().returnsThis(), json: sinon.stub() };
+    const listReq = { params: { id: 1 } };
+    await accountController.getAllSubAccountsByParentAccountId(listReq, listRes);
+    expect(listRes.json.firstCall.args[0].subAccounts).to.have.length(1);
+  });
+});

--- a/ledger/server/tests/entries.test.js
+++ b/ledger/server/tests/entries.test.js
@@ -1,0 +1,77 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const proxyquire = require('proxyquire');
+
+// Fake in-memory store for transactions
+const transactions = [];
+
+const queryStub = sinon.stub().callsFake(async (query, values) => {
+  if (/INSERT INTO transactions/i.test(query)) {
+    const row = {
+      account_number: values[0],
+      sub_account_number: values[1],
+      fk_user_id: values[2],
+      amount: values[3],
+      timestamp: values[4],
+      reference: values[5],
+      note: values[6],
+      transaction_id: values[7],
+    };
+    transactions.push(row);
+    return { rows: [row] };
+  }
+  return { rows: [] };
+});
+
+const entriesController = proxyquire('../controllers/entriesController', {
+  '../db/config': { query: queryStub },
+});
+
+describe('entriesController.createEntry', () => {
+  beforeEach(() => {
+    transactions.length = 0;
+    queryStub.resetHistory();
+  });
+
+  it('stores entries and ensures debit/credit balance', async () => {
+    const res = { status: sinon.stub().returnsThis(), json: sinon.stub() };
+
+    const debitReq = {
+      body: {
+        account_number: '1001',
+        sub_account_number: '100101',
+        fk_user_id: 1,
+        amount: 100,
+        timestamp: new Date(),
+        reference: 'debit',
+        note: 'debit entry',
+        transaction_id: 1,
+      },
+    };
+
+    await entriesController.createEntry(debitReq, res);
+
+    const creditReq = {
+      body: {
+        account_number: '2001',
+        sub_account_number: '200101',
+        fk_user_id: 1,
+        amount: -100,
+        timestamp: new Date(),
+        reference: 'credit',
+        note: 'credit entry',
+        transaction_id: 1,
+      },
+    };
+
+    await entriesController.createEntry(creditReq, res);
+
+    const total = transactions
+      .filter((t) => t.transaction_id === 1)
+      .reduce((sum, t) => sum + Number(t.amount), 0);
+
+    expect(total).to.equal(0);
+    expect(queryStub.callCount).to.equal(2);
+    expect(res.status.calledWith(201)).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
- add mocha/chai test setup and scripts
- test posting balanced transactions
- test account and sub-account CRUD

## Testing
- `npm test --silent` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ddc1119083329e4a90b75c19cf8f