### PR TITLE
Add journal entries support

### DIFF
--- a/ledger/client/src/components/entries/CreateEntries.jsx
+++ b/ledger/client/src/components/entries/CreateEntries.jsx
@@ -9,14 +9,13 @@ import { MdClose } from "react-icons/md";
 
 
 function CreateEntries() {
-  const [accountNumber, setAccountNumber] = useState("");
-  const [subAccountNumber, setSubAccountNumber] = useState("");
+  const [debitAccountId, setDebitAccountId] = useState("");
+  const [creditAccountId, setCreditAccountId] = useState("");
   const [userId, setUserId] = useState("");
   const [amount, setAmount] = useState("");
   const [timestamp, setTimestamp] = useState("");
   const [reference, setReference] = useState("");
   const [note, setNote] = useState("");
-  const [transactionId, setTransactionId] = useState("");
 
   const [isLoading, setIsLoading] = useState(false);
   useEffect(() => {
@@ -32,14 +31,13 @@ function CreateEntries() {
     e.preventDefault();
 
     const newEntry = {
-      account_number: accountNumber,
-      sub_account_number: subAccountNumber,
+      debit_account_id: debitAccountId,
+      credit_account_id: creditAccountId,
       fk_user_id: userId,
       amount,
       timestamp,
       reference,
       note,
-      transaction_id: transactionId,
     };
 
     try {
@@ -71,16 +69,16 @@ function CreateEntries() {
     <form onSubmit={saveAccount}  class="px-4 py-4 text-sm" >
        <div class="flex flex-col gap-4">
       <TextField
-        label="Account Number"
-        value={accountNumber}
-        onChange={(e) => setAccountNumber(e.target.value)}
+        label="Debit Account ID"
+        value={debitAccountId}
+        onChange={(e) => setDebitAccountId(e.target.value)}
         required
         fullWidth
       />
       <TextField
-        label="Sub Account Number"
-        value={subAccountNumber}
-        onChange={(e) => setSubAccountNumber(e.target.value)}
+        label="Credit Account ID"
+        value={creditAccountId}
+        onChange={(e) => setCreditAccountId(e.target.value)}
         required
         fullWidth
       />
@@ -116,13 +114,6 @@ function CreateEntries() {
         label="Note"
         value={note}
         onChange={(e) => setNote(e.target.value)}
-        required
-        fullWidth
-      />
-      <TextField
-        label="Transaction ID"
-        value={transactionId}
-        onChange={(e) => setTransactionId(e.target.value)}
         required
         fullWidth
       />

--- a/ledger/docs/ERD.md
+++ b/ledger/docs/ERD.md
@@ -1,0 +1,18 @@
+# Database Structure Update
+
+The schema now includes a `journal_entries` table used to record paired debit and credit transactions.
+
+```sql
+CREATE TABLE journal_entries (
+    id SERIAL PRIMARY KEY,
+    debit_account_id INT NOT NULL REFERENCES accounts(id),
+    credit_account_id INT NOT NULL REFERENCES accounts(id),
+    fk_user_id INT NOT NULL REFERENCES users(id),
+    amount DECIMAL(18,2) NOT NULL,
+    timestamp TIMESTAMP NOT NULL DEFAULT NOW(),
+    reference VARCHAR(255),
+    note TEXT
+);
+```
+
+Each call to the entry API inserts rows into both the `transactions` table and `journal_entries` to ensure debits equal credits.

--- a/ledger/server/controllers/entriesController.js
+++ b/ledger/server/controllers/entriesController.js
@@ -1,39 +1,108 @@
 // entriesController.js
 /* eslint-disable camelcase */
-const { Pool } = require("pg");
 const pool = require("../db/config");
 
 const createEntry = async (req, res) => {
   try {
-    const { account_number, sub_account_number, fk_user_id, amount, timestamp, reference, note, transaction_id } = req.body;
+    const {
+      debit_account_id,
+      credit_account_id,
+      fk_user_id,
+      amount,
+      timestamp,
+      reference,
+      note,
+    } = req.body;
 
-    // Insert a new transaction into the transactions table
-    const query = `
-      INSERT INTO transactions (account_number, sub_account_number, fk_user_id, amount, timestamp, reference, note, transaction_id)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-      RETURNING *;
-    `;
+    if (!debit_account_id || !credit_account_id || !amount) {
+      return res.status(400).json({ error: "Missing required fields" });
+    }
 
-    const values = [account_number, sub_account_number, fk_user_id, amount, timestamp, reference, note, transaction_id];
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
 
-    const result = await pool.query(query, values);
+      const debitMasterRes = await client.query(
+        "SELECT master_account FROM accounts WHERE id = $1",
+        [debit_account_id]
+      );
+      const creditMasterRes = await client.query(
+        "SELECT master_account FROM accounts WHERE id = $1",
+        [credit_account_id]
+      );
 
-    // Send a success response with the created transaction
-    res.status(201).json({ transaction: result.rows[0] });
-    console.log("Transaction Posted");
+      if (debitMasterRes.rows.length === 0 || creditMasterRes.rows.length === 0) {
+        await client.query("ROLLBACK");
+        return res.status(404).json({ error: "Account not found" });
+      }
+
+      const debitMaster = debitMasterRes.rows[0].master_account;
+      const creditMaster = creditMasterRes.rows[0].master_account;
+
+      const transQuery = `
+        INSERT INTO transactions (fk_master_account, fk_user_id, amount, timestamp, reference, note)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        RETURNING *;
+      `;
+
+      const debitTx = await client.query(transQuery, [
+        debitMaster,
+        fk_user_id,
+        amount,
+        timestamp,
+        reference,
+        note,
+      ]);
+
+      const creditTx = await client.query(transQuery, [
+        creditMaster,
+        fk_user_id,
+        -amount,
+        timestamp,
+        reference,
+        note,
+      ]);
+
+      const journalQuery = `
+        INSERT INTO journal_entries (debit_account_id, credit_account_id, fk_user_id, amount, timestamp, reference, note)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        RETURNING *;
+      `;
+
+      const journalRes = await client.query(journalQuery, [
+        debit_account_id,
+        credit_account_id,
+        fk_user_id,
+        amount,
+        timestamp,
+        reference,
+        note,
+      ]);
+
+      await client.query("COMMIT");
+
+      res.status(201).json({
+        entry: journalRes.rows[0],
+        debitTransaction: debitTx.rows[0],
+        creditTransaction: creditTx.rows[0],
+      });
+    } catch (e) {
+      await client.query("ROLLBACK");
+      console.error(e);
+      res.status(500).json({ error: "Internal server error" });
+    } finally {
+      client.release();
+    }
   } catch (error) {
-    // Handle any errors and send an error response
     console.error(error);
     res.status(500).json({ error: "Internal server error" });
   }
 };
 
-
 const getEntriesbyPeriod = async (req, res) => {
   try {
     const { period } = req.query;
 
-    // Fetch entries by period from the transactions table
     const query = `
       SELECT * FROM transactions
       ORDER BY timestamp DESC
@@ -42,16 +111,12 @@ const getEntriesbyPeriod = async (req, res) => {
     const values = [period];
     const result = await pool.query(query, values);
 
-    // Send a success response with the retrieved entries
     res.status(200).json({ entries: result.rows });
-    console.log("Retrieved entries by period");
   } catch (error) {
-    // Handle any errors and send an error response
     console.error(error);
     res.status(500).json({ error: "Internal server error" });
   }
 };
-
 
 module.exports = {
   createEntry,

--- a/ledger/server/db/schema/06_create_journal_entries.sql
+++ b/ledger/server/db/schema/06_create_journal_entries.sql
@@ -1,0 +1,14 @@
+-- Drop the existing journal_entries table if it exists
+DROP TABLE IF EXISTS journal_entries CASCADE;
+
+-- Create a new table for journal entries
+CREATE TABLE journal_entries (
+    id SERIAL PRIMARY KEY,
+    debit_account_id INT NOT NULL REFERENCES accounts(id),
+    credit_account_id INT NOT NULL REFERENCES accounts(id),
+    fk_user_id INT NOT NULL REFERENCES users(id),
+    amount DECIMAL(18, 2) NOT NULL,
+    timestamp TIMESTAMP NOT NULL DEFAULT NOW(),
+    reference VARCHAR(255),
+    note TEXT
+);

--- a/ledger/server/db/seeds/05_journal_entries.sql
+++ b/ledger/server/db/seeds/05_journal_entries.sql
@@ -1,0 +1,6 @@
+-- Seed data for journal_entries table
+INSERT INTO journal_entries (debit_account_id, credit_account_id, fk_user_id, amount, timestamp, reference, note)
+VALUES
+    (1, 5, 1, 100.00, '2023-01-01', 'Seed sale', 'Seed entry 1'),
+    (6, 1, 1, 500.00, '2023-01-05', 'Seed rent payment', 'Seed entry 2'),
+    (2, 5, 1, 300.00, '2023-01-10', 'Seed invoice', 'Seed entry 3');


### PR DESCRIPTION
## Summary
- add `journal_entries` table
- seed journal entries
- update server entry creation to insert paired debit/credit rows
- update React form for new fields
- document new ERD structure

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test --silent` in client (fails: react-scripts not found)


------
https://chatgpt.com/codex/tasks/task_e_6856ddad34e08332aeec01fb85745ae3