### PR TITLE
Implement entry period retrieval tests

### DIFF
--- a/ledger/server/tests/entries.test.js
+++ b/ledger/server/tests/entries.test.js
@@ -23,14 +23,42 @@ const queryStub = sinon.stub().callsFake(async (query, values) => {
   return { rows: [] };
 });
 
+const transactionServiceStub = {
+  createTransactionWithBlockchain: sinon.stub().resolves(),
+  getEntriesByPeriod: sinon.stub().resolves([]),
+};
+
 const entriesController = proxyquire('../controllers/entriesController', {
   '../db/config': { query: queryStub },
+  '../services/transactionService': transactionServiceStub,
+});
+
+describe('entriesController.getEntriesByPeriod', () => {
+  beforeEach(() => {
+    transactionServiceStub.getEntriesByPeriod.resetHistory();
+  });
+
+  it('retrieves recent entries', async () => {
+    const fakeEntries = [{ id: 1 }, { id: 2 }, { id: 3 }];
+    transactionServiceStub.getEntriesByPeriod.resolves(fakeEntries);
+
+    const req = { query: { period: '3' } };
+    const res = { status: sinon.stub().returnsThis(), json: sinon.stub() };
+
+    await entriesController.getEntriesByPeriod(req, res);
+
+    expect(transactionServiceStub.getEntriesByPeriod.calledWith(3)).to.be.true;
+    expect(res.status.calledWith(200)).to.be.true;
+    expect(res.json.firstCall.args[0].entries).to.have.length(3);
+  });
 });
 
 describe('entriesController.createEntry', () => {
   beforeEach(() => {
     transactions.length = 0;
     queryStub.resetHistory();
+    transactionServiceStub.createTransactionWithBlockchain.resetHistory();
+    transactionServiceStub.getEntriesByPeriod.resetHistory();
   });
 
   it('stores entries and ensures debit/credit balance', async () => {
@@ -73,5 +101,6 @@ describe('entriesController.createEntry', () => {
     expect(total).to.equal(0);
     expect(queryStub.callCount).to.equal(2);
     expect(res.status.calledWith(201)).to.be.true;
+    expect(transactionServiceStub.createTransactionWithBlockchain.callCount).to.equal(2);
   });
 });


### PR DESCRIPTION
## Summary
- stub out transaction service in entry tests
- add tests for retrieving recent entries
- verify that entries routes call `getEntriesByPeriod`

## Testing
- `npm test --prefix ledger/server` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857112a308083328f94778808942527